### PR TITLE
[#168444718] Switch to away from buildkite docker env vars

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 steps:
   - name: ':rspec: RSpec'
-    command: bundle exec rspec
+    command:
+      - docker build . -t contract_value_object:$BUILDKITE_BUILD_ID
+      - docker run -t contract_value_object:$BUILDKITE_BUILD_ID bundle exec rspec
     timeout_in_minutes: 10
-    env:
-      BUILDKITE_DOCKER: 'true'


### PR DESCRIPTION
When switching the v3, the use of `BUILDKITE_DOCKER_FILE` and `BUILDKITE_DOCKER` will break builds. This pull request is a preventative change to handle the break that will come with the upgrade to v3.